### PR TITLE
Unset CDPATH for duration of bootstrap script

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -6,6 +6,9 @@ if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
     exit 1
 fi
 
+# see #849
+unset CDPATH
+
 ########################################
 # Common meta-language implementation. Syntax:
 #


### PR DESCRIPTION
CDPATH causes the `cd` command to output the directory it's going into
sometimes.

This actually fixes #849, I got bit by this