### PR TITLE
confdata: fix format overflow warnings for tmpname, newname

### DIFF
--- a/kconfig/confdata.c
+++ b/kconfig/confdata.c
@@ -745,7 +745,7 @@ int conf_write(const char *name)
 	struct menu *menu;
 	const char *basename;
 	const char *str;
-	char dirname[PATH_MAX+1], tmpname[PATH_MAX+1], newname[PATH_MAX+1];
+	char dirname[PATH_MAX+1], tmpname[PATH_MAX+22], newname[PATH_MAX+8];
 	char *env;
 
 	dirname[0] = 0;


### PR DESCRIPTION
Increase the size of tmpname and newname to silence this warning [-Wformat-overflow=] and to prevent further warnings for newer GCC's releases GCC 8.1+