### PR TITLE
Don't force -fPIC when building libelf

### DIFF
--- a/scripts/build/companion_libs/200-libelf.sh
+++ b/scripts/build/companion_libs/200-libelf.sh
@@ -125,7 +125,7 @@ do_libelf_backend() {
     CT_DoExecLog CFG                                        \
     CC="${host}-gcc"                                        \
     RANLIB="${host}-ranlib"                                 \
-    CFLAGS="${cflags} -fPIC"                                \
+    CFLAGS="${cflags}"                                \
     LDFLAGS="${ldflags}"                                    \
     ${CONFIG_SHELL}                                         \
     "${CT_SRC_DIR}/libelf/configure"                        \


### PR DESCRIPTION
microblaze-nommu (BFLT) need libelf to be built without -fPIC,
but crosstool-ng forces -fPIC.

It is not clear if this needs to be configurable per-platform

Signed-off-by: Steve Bennett <steveb@workware.net.au>